### PR TITLE
Add blueprint-compiler package to dependencies for Fedora variants

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -213,6 +213,7 @@ sudo dnf install \
   gtk4-layer-shell-devel \
   zig \
   libadwaita-devel \
+  blueprint-compiler \
   gettext
 ```
 


### PR DESCRIPTION
To build v1.2.0 on Fedora today, I'd had to install the blueprint-compiler.  The correct package for this on Fedora 42 is `blueprint-compiler` (same as in the Gentoo section).